### PR TITLE
Retry finding the DB Server port twice before giving up.

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/dbserver/ConnectionManager.java
+++ b/src/main/java/org/deepsymmetry/beatlink/dbserver/ConnectionManager.java
@@ -229,8 +229,6 @@ public class ConnectionManager extends LifecycleParticipant {
         return result;
     }
 
-    private static final int DB_SERVER_QUERY_RETRIES = 2;
-
     /**
      * Our announcement listener watches for devices to appear on the network so we can ask them for their database
      * server port, and when they disappear discards all information about them.


### PR DESCRIPTION
This gives us a chance to find the port if ConnectionManager jumps in slightly too early after a network disconnection. This seems to help when a CDJ drops of the network then comes back.

I find that this is more responsive if I also lower the socket timeout from 10s to 3s in my application, otherwise it will just take a long time to get back on track.