### PR TITLE
Fix media name length parsing for CDJ-3000

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/MediaDetails.java
+++ b/src/main/java/org/deepsymmetry/beatlink/MediaDetails.java
@@ -148,12 +148,21 @@ public class MediaDetails {
         }
         mediaType = type;
 
+        // Media name length is 0x40 or UTF-16 NUL, which ever comes first.
+        int mediaNameLength = 0x40;
+        for (int i=0x2c; i<0x6b; i+=2) {
+            if (packetCopy[i] == 0x00 && packetCopy[i+1] == 0x00) {
+                mediaNameLength = i-0x2c;
+                break;
+            }
+        }
+
         if (hostPlayer >= 40) {  // Rekordbox mobile does not send media name or creation date.
             name = "rekordbox mobile";
             creationDate = "";
         } else {
             try {
-                name = new String(packetCopy, 0x2c, 0x40, "UTF-16BE").trim();
+                name = new String(packetCopy, 0x2c, mediaNameLength, "UTF-16BE").trim();
                 creationDate = new String(packetCopy, 0x6c, 0x18, "UTF-16BE").trim();
             } catch (UnsupportedEncodingException e) {
                 throw new IllegalStateException("Java no longer supports UTF-16BE encoding?!", e);

--- a/src/main/java/org/deepsymmetry/beatlink/MediaDetails.java
+++ b/src/main/java/org/deepsymmetry/beatlink/MediaDetails.java
@@ -100,17 +100,20 @@ public class MediaDetails {
     public static final int MINIMUM_PACKET_SIZE = 0xc0;
 
     /**
-     * Given a source array, return the UTF-16 string length in bytes by finding UTF-16 NUL sequence.
-     * If UTF-16 NUL sequence is not found, maxLength is returned.
+     * Given a source byte array, return the UTF-16 string length in bytes by finding a UTF-16 NUL sequence.
+     * If a UTF-16 NUL sequence is not found, maxLength or source.length-offset is returned, which ever is smaller.
      * 
      * @param source the source byte array representing a UTF-16 string
      * @param offset the byte offset to start at in the source byte array
      * @param maxLength the maximum length of the UTF-16 string (in bytes)
-     * @return the length in number of bytes excluding the UTF-16 NUL sequence, else maxLength
+     * 
+     * @return the length in number of bytes excluding the UTF-16 NUL sequence, else maxLength or source.length-offset, which ever is smaller.
      */
     private int getUTF16StringLength(byte[] source, int offset, int maxLength) {
         int numBytes = maxLength;
-        for (int i=offset; i<offset+maxLength-1; i+=2) {
+        int clampedMaxLength = Math.min(maxLength, source.length-offset);
+        
+        for (int i=offset; i<offset+clampedMaxLength-1; i+=2) {
             if (source[i] == 0x00 && source[i+1] == 0x00) {
                 numBytes = i-offset;
                 break;


### PR DESCRIPTION
As noticed in https://github.com/Deep-Symmetry/dysentery/pull/28, CDJ-3000 seems to parse `MediaDetails` `name` and `creationDate` fields slightly differently than older players. Older players will pad zeros in the name field, where CDJ-3000 will NUL terminate it and leave junk on the end.

This ends up looking funny in beat-link-trigger:

<img width="491" alt="Screen Shot 2020-10-09 at 12 52 24 pm" src="https://user-images.githubusercontent.com/360201/95575032-4ce85500-0a2e-11eb-89b9-c5d6b17fb4ae.png">

Some logging before the fix:

**Name: NUDGE TRAX USB**

```
XDJ-700

000000:  51 73 70 74 31 57 6d 4a 4f 4c 06 58 44 4a 2d 37   |  Qspt1WmJOLXDJ-7
000016:  30 30 00 00 00 00 00 00 00 00 00 00 00 00 00 01   |  00
000032:  00 02 00 9c 00 00 00 02 00 00 00 03 00 4e 00 55   |  �NU
000048:  00 44 00 47 00 45 00 20 00 54 00 52 00 41 00 58   |  DGE TRAX
000064:  00 20 00 55 00 53 00 42 00 00 00 00 00 00 00 00   |   USB
000080:  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |  
000096:  00 00 00 00 00 00 00 00 00 00 00 00 00 32 00 30   |  20
000112:  00 32 00 30 00 2d 00 30 00 39 00 2d 00 32 00 32   |  20-09-22
000128:  00 00 00 00 00 31 00 30 00 30 00 30 00 00 00 00   |  1000
000144:  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |  
000160:  00 00 00 00 00 00 04 4f 00 00 01 01 00 00 00 42   |  OB
000176:  00 00 00 0e a2 ab 00 00 00 00 00 01 ae 2f 00 00   |  ���/

MediaDetails[slotReference:SlotReference[player:2, slot:USB_SLOT], name:NUDGE TRAX USB, creationDate:2020-09-22, mediaType:REKORDBOX, trackCount:1103, playlistCount:66, totalSize:62858657792, freeSpace:7217283072]

------

CDJ-3000

000000:  51 73 70 74 31 57 6d 4a 4f 4c 06 43 44 4a 2d 33   |  Qspt1WmJOLCDJ-3
000016:  30 30 30 00 00 00 00 00 00 00 00 00 00 00 00 01   |  000
000032:  00 03 00 9c 00 00 00 03 00 00 00 03 00 4e 00 55   |  �NU
000048:  00 44 00 47 00 45 00 20 00 54 00 52 00 41 00 58   |  DGE TRAX
000064:  00 20 00 55 00 53 00 42 00 00 00 00 b4 60 3d 87   |   USB�`=�
000080:  00 00 00 00 00 e1 00 00 00 00 00 00 01 48 28 00   |  �H(
000096:  ff ff 00 00 01 48 28 00 ff ff 00 00 00 32 00 30   |  ��H(��20
000112:  00 32 00 30 00 2d 00 30 00 39 00 2d 00 32 00 32   |  20-09-22
000128:  00 00 6d 63 00 31 00 30 00 30 00 30 00 00 00 00   |  mc1000
000144:  73 2f 61 64 a7 60 38 d5 00 00 00 00 00 fa 00 00   |  s/ad�`8��
000160:  00 00 00 00 00 00 04 4f 00 00 01 01 00 00 00 46   |  OF
000176:  00 00 00 0e a2 ab 00 00 00 00 00 01 ae 2f 00 00   |  ���/

MediaDetails[slotReference:SlotReference[player:3, slot:USB_SLOT], name:NUDGE TRAX USB둠㶇áň⠀￿ň⠀￿, creationDate:2020-09-22浣, mediaType:REKORDBOX, trackCount:1103, playlistCount:70, totalSize:62858657792, freeSpace:7217283072]
```



**Name: NUDGE TRAX USB 1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ**

```
XDJ-700

000000:  51 73 70 74 31 57 6d 4a 4f 4c 06 58 44 4a 2d 37   |  Qspt1WmJOLXDJ-7
000016:  30 30 00 00 00 00 00 00 00 00 00 00 00 00 00 01   |  00
000032:  00 02 00 9c 00 00 00 02 00 00 00 03 00 4e 00 55   |  �NU
000048:  00 44 00 47 00 45 00 20 00 54 00 52 00 41 00 58   |  DGE TRAX
000064:  00 20 00 55 00 53 00 42 00 20 00 31 00 32 00 33   |   USB 123
000080:  00 34 00 35 00 36 00 37 00 38 00 39 00 30 00 41   |  4567890A
000096:  00 42 00 43 00 44 00 45 00 46 00 00 00 32 00 30   |  BCDEF20
000112:  00 32 00 30 00 2d 00 30 00 39 00 2d 00 32 00 32   |  20-09-22
000128:  00 00 00 00 00 31 00 30 00 30 00 30 00 00 00 00   |  1000
000144:  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   |  
000160:  00 00 00 00 00 00 04 4f 00 00 01 01 00 00 00 42   |  OB
000176:  00 00 00 0e a2 ab 00 00 00 00 00 01 ae 30 c0 00   |  ���0�

MediaDetails[slotReference:SlotReference[player:2, slot:USB_SLOT], name:NUDGE TRAX USB 1234567890ABCDEF, creationDate:2020-09-22, mediaType:REKORDBOX, trackCount:1103, playlistCount:66, totalSize:62858657792, freeSpace:7217397760]

------

CDJ-3000

000000:  51 73 70 74 31 57 6d 4a 4f 4c 06 43 44 4a 2d 33   |  Qspt1WmJOLCDJ-3
000016:  30 30 30 00 00 00 00 00 00 00 00 00 00 00 00 01   |  000
000032:  00 03 00 9c 00 00 00 03 00 00 00 03 00 4e 00 55   |  �NU
000048:  00 44 00 47 00 45 00 20 00 54 00 52 00 41 00 58   |  DGE TRAX
000064:  00 20 00 55 00 53 00 42 00 20 00 31 00 32 00 33   |   USB 123
000080:  00 34 00 35 00 36 00 37 00 38 00 39 00 30 00 41   |  4567890A
000096:  00 42 00 43 00 44 00 45 00 46 00 47 00 32 00 30   |  BCDEFG20
000112:  00 32 00 30 00 2d 00 30 00 39 00 2d 00 32 00 32   |  20-09-22
000128:  00 00 41 44 00 31 00 30 00 30 00 30 00 00 00 00   |  AD1000
000144:  73 2f 61 64 a7 60 38 d5 00 00 00 00 00 fa 00 00   |  s/ad�`8��
000160:  00 00 00 00 00 00 04 4f 00 00 01 01 00 00 00 46   |  OF
000176:  00 00 00 0e a2 ab 00 00 00 00 00 01 ae 30 c0 00   |  ���0�

MediaDetails[slotReference:SlotReference[player:3, slot:USB_SLOT], name:NUDGE TRAX USB 1234567890ABCDEFG, creationDate:2020-09-22䅄, mediaType:REKORDBOX, trackCount:1103, playlistCount:70, totalSize:62858657792, freeSpace:7217397760]
```


After fix:
```
XDJ-700:
MediaDetails[slotReference:SlotReference[player:2, slot:USB_SLOT], name:NUDGE TRAX USB 1234567890ABCDEF, creationDate:2020-09-22, mediaType:REKORDBOX, trackCount:1103, playlistCount:66, totalSize:62858657792, freeSpace:7216709632]

CDJ-3000:
MediaDetails[slotReference:SlotReference[player:3, slot:USB_SLOT], name:NUDGE TRAX USB 1234567890ABCDEFG, creationDate:2020-09-22, mediaType:REKORDBOX, trackCount:1103, playlistCount:70, totalSize:62858657792, freeSpace:7216709632]
```

If the name field takes up the maximum length of the field (`0x40`), CDJ-3000 will not NUL terminate it, where XDJ-700 will. This has the side effect of CDJ-3000 being able to store 1 extra character.

This PR fixes `MediaDetails` `name` and `creationDate` parsing.


(Side note: curious that CDJ-3000 detects 70 playlists where the XDJ-700 detects 66. May look into this a bit later).