### PR TITLE
Caffeine Cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.deepsymmetry</groupId>
     <artifactId>beat-link</artifactId>
-    <version>7.3.0</version>
+    <version>7.4.0</version>
     <packaging>jar</packaging>
 
     <name>beat-link</name>
@@ -95,9 +95,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
-            <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>1.4.2</version>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
         </dependency>
     </dependencies>
 
@@ -244,7 +244,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>6</release>
+                    <release>8</release>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Use `com.github.ben-manes.caffeine`.

According to upstream docs:

> [Caffeine](https://github.com/ben-manes/caffeine) is the Java 8 successor to ConcurrentLinkedHashMap and Guava's cache. Projects should prefer Caffeine and migrate when requiring JDK8 or higher. The previous caching projects are supported in maintenance mode.

Caffeine [supports native-image](https://github.com/ben-manes/caffeine/blob/master/examples/graal-native) which `com.googlecode.concurrentlinkedhashmap` does not.

Tested locally with:

```bash
mvn -Dgpg.skip=true -Dmaven.javadoc.skip=true install
```
