### PR TITLE
Cprepos virtual rekordbox

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -639,7 +639,7 @@ public class CdjStatus extends DeviceUpdate {
         firmwareVersion = new String(packetBytes, 124, 4).trim();
         handingMasterToDevice = Util.unsign(packetBytes[MASTER_HAND_OFF]);
 
-        if (deviceName.equals("OPUS-QUAD")) {
+        if (Util.isOpusQuad(deviceName)) {
             trackSourcePlayer = translateOpusPlayerNumbers(packetBytes[40]);
             trackSourceSlot = findOpusTrackSourceSlot();
         } else {

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -519,22 +519,6 @@ public class CdjStatus extends DeviceUpdate {
     }
 
     /**
-     * Adjust the player numbers from the Opus-Quad so that they are 1-4 as expected.
-     *
-     * @return the proper value
-     */
-    private int translateOpusPlayerNumbers(int reportedPlayerNumber) {
-        switch (reportedPlayerNumber){
-            case 9: return 1;
-            case 10: return 2;
-            case 11: return 3;
-            case 12: return 4;
-        }
-
-        return reportedPlayerNumber;
-    }
-
-    /**
      * Determine the enum value corresponding to the track type found in the packet.
      *
      * @return the proper value

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -646,7 +646,6 @@ public class CdjStatus extends DeviceUpdate {
             trackSourcePlayer = packetBytes[40];
             trackSourceSlot = findTrackSourceSlot();
         }
-        logger.info("cdj status {}", this);
     }
 
     /**

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
@@ -56,15 +56,10 @@ public class DeviceAnnouncement {
 
     /**
      * Constructor sets all the immutable interpreted fields based on the packet content.
+     * This Constructor allows you to inject Device Number.
      *
      * @param packet the device announcement packet that was received
-     * @param deviceNumber the device number that we want to inject
-     */
-
-    /**
-     *
-     * @param packet
-     * @param deviceNumber
+     * @param deviceNumber the device number you want to emulate
      */
     public DeviceAnnouncement(DatagramPacket packet, int deviceNumber) {
         if (packet.getLength() != 54) {

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceAnnouncement.java
@@ -55,6 +55,30 @@ public class DeviceAnnouncement {
     }
 
     /**
+     * Constructor sets all the immutable interpreted fields based on the packet content.
+     *
+     * @param packet the device announcement packet that was received
+     * @param deviceNumber the device number that we want to inject
+     */
+
+    /**
+     *
+     * @param packet
+     * @param deviceNumber
+     */
+    public DeviceAnnouncement(DatagramPacket packet, int deviceNumber) {
+        if (packet.getLength() != 54) {
+            throw new IllegalArgumentException("Device announcement packet must be 54 bytes long");
+        }
+        address = packet.getAddress();
+        packetBytes = new byte[packet.getLength()];
+        System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
+        timestamp = System.currentTimeMillis();
+        name = new String(packetBytes, 12, 20).trim();
+        number = deviceNumber;
+    }
+
+    /**
      * Get the address on which this device was seen.
      *
      * @return the network address from which the device is communicating

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -205,7 +205,7 @@ public class DeviceFinder extends LifecycleParticipant {
     /**
      * <p>In normal operation (with Pro DJ Link devices), start listening for device announcements and keeping
      * track of the DJ Link devices visible on the network.  If VirtualRekordbox is running, then we are actually
-     * in Opus Quad compatibility mode, and will do far less,acting as a proxy for packets that it is responsible
+     * in Opus Quad compatibility mode, and will do far less, acting as a proxy for packets that it is responsible
      * for receiving.</p>
      *
      * <p>If already active, has no effect.</p>

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -336,6 +336,7 @@ public class DeviceFinder extends LifecycleParticipant {
      * as long as the Virtual CDJ is active.
      *
      * @return the devices which have been heard from recently enough to be considered present on the network
+     *
      * @throws IllegalStateException if the {@code DeviceFinder} is not active
      */
     public Set<DeviceAnnouncement> getCurrentDevices() {
@@ -352,7 +353,9 @@ public class DeviceFinder extends LifecycleParticipant {
      * with the specified device number, if any.
      *
      * @param deviceNumber the device number of interest
+     *
      * @return the matching announcement or null if no such device has been heard from
+     *
      * @throws IllegalStateException if the {@code DeviceFinder} is not active
      */
     public DeviceAnnouncement getLatestAnnouncementFrom(int deviceNumber) {
@@ -370,7 +373,6 @@ public class DeviceFinder extends LifecycleParticipant {
      */
     private final Set<DeviceAnnouncementListener> deviceListeners =
             Collections.newSetFromMap(new ConcurrentHashMap<DeviceAnnouncementListener, Boolean>());
-
     /**
      * Adds the specified device announcement listener to receive device announcements when DJ Link devices
      * are found on or leave the network. If {@code listener} is {@code null} or already present in the list

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -263,9 +263,8 @@ public class DeviceFinder extends LifecycleParticipant {
                                         DeviceAnnouncement announcement = new DeviceAnnouncement(packet);
 
                                         if (Util.isOpusQuad(announcement.getDeviceName())) {
-                                            createAndProcessOpusAnnouncements(packet);
 
-                                            logger.error("{}",devices);
+                                            createAndProcessOpusAnnouncements(packet);
                                         } else {
 
                                             processAnnouncement(announcement);

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceUpdate.java
@@ -59,7 +59,12 @@ public abstract class DeviceUpdate {
         System.arraycopy(packet.getData(), 0, packetBytes, 0, packet.getLength());
         deviceName = new String(packetBytes, 11, 20).trim();
         preNexusCdj = deviceName.startsWith("CDJ") && (deviceName.endsWith("900") || deviceName.endsWith("2000"));
-        deviceNumber = Util.unsign(packetBytes[33]);
+
+        if (Util.isOpusQuad(deviceName)){
+            deviceNumber = translateOpusPlayerNumbers(packetBytes[40]);
+        } else {
+            deviceNumber = Util.unsign(packetBytes[33]);
+        }
     }
 
     /**
@@ -195,6 +200,22 @@ public abstract class DeviceUpdate {
      */
     @SuppressWarnings("WeakerAccess")
     public abstract boolean isBeatWithinBarMeaningful();
+
+    /**
+     * Adjust the player numbers from the Opus-Quad so that they are 1-4 as expected.
+     *
+     * @return the proper value
+     */
+    int translateOpusPlayerNumbers(int reportedPlayerNumber) {
+        switch (reportedPlayerNumber){
+            case 9: return 1;
+            case 10: return 2;
+            case 11: return 3;
+            case 12: return 4;
+        }
+
+        return reportedPlayerNumber;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/org/deepsymmetry/beatlink/Util.java
+++ b/src/main/java/org/deepsymmetry/beatlink/Util.java
@@ -969,6 +969,9 @@ public class Util {
         return artPath.replaceFirst("(\\.\\w+$)", "_m$1");
     }
 
+    public static boolean isOpusQuad(String deviceName){
+        return deviceName.equals("OPUS-QUAD");
+    }
 
     /**
      * Prevent instantiation.

--- a/src/main/java/org/deepsymmetry/beatlink/Util.java
+++ b/src/main/java/org/deepsymmetry/beatlink/Util.java
@@ -81,6 +81,14 @@ public class Util {
         DEVICE_HELLO(0x0a, "Device Hello", DeviceFinder.ANNOUNCEMENT_PORT),
 
         /**
+         * These are the bytes that all in one players like the Opus-Quad send to announce to Rekordbox Lighting that
+         * it is available on the network. Once VirtualRekordbox sends its hello message to the player, it stops sending
+         * these and starts sending CdjStatus updates.
+         */
+        DEVICE_REKORDBOX_LIGHTING_HELLO_BYTES(0x10, "Rekordbox Lighting Hello Bytes", VirtualCdj.UPDATE_PORT),
+
+
+        /**
          * A series of three of these is sent at 300ms intervals when a device is starting to establish its
          * device number.
          */
@@ -131,6 +139,13 @@ public class Util {
          * Sadly, the same number is used (on port 50000) as part of the CDJ startup process.
          */
         CDJ_STATUS(0x0a, "CDJ Status", VirtualCdj.UPDATE_PORT),
+
+        /**
+         * Metadata that includes track album art, possibly waveforms and more. We do not use this information at the moment
+         * because it is not complete enough to support all of the Beat Link Trigger functionality. Instead, we download
+         * the track data from a Rekordbox USB.
+         */
+        OPUS_METADATA(0x56, "OPUS Metadata", VirtualCdj.UPDATE_PORT),
 
         /**
          * A command to load a particular track; usually sent by rekordbox.

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
@@ -60,11 +60,6 @@ public class VirtualCdj extends LifecycleParticipant {
         return proxyingForVirtualRekordbox.get();
     }
 
-    public void setInOpusQuadCompatibilityMode(boolean inOpusCompatibilityMode){
-        proxyingForVirtualRekordbox.set(inOpusCompatibilityMode);
-    }
-
-
     /**
      * Check whether we are presently posing as a virtual CDJ and receiving device status updates.
      *
@@ -1121,12 +1116,11 @@ public class VirtualCdj extends LifecycleParticipant {
     public synchronized boolean start() throws SocketException {
         if (!isRunning()) {
             // See if we are just going to proxy information for VirtualRekordbox.
-            // TODO uncomment once this exists.
-//            VirtualRekordbox.getInstance().addLifecycleListener(virtualRekordboxLifecycleListener);
-//            if (VirtualRekordbox.getInstance().isRunning()) {
-//                proxyingForVirtualRekordbox.set(true);
-//                return true;
-//            }
+            VirtualRekordbox.getInstance().addLifecycleListener(virtualRekordboxLifecycleListener);
+            if (VirtualRekordbox.getInstance().isRunning()) {
+                proxyingForVirtualRekordbox.set(true);
+                return true;
+            }
 
             // Set up so we know we have to shut down if the DeviceFinder shuts down.
             DeviceFinder.getInstance().addLifecycleListener(deviceFinderLifecycleListener);

--- a/src/main/test/org/deepsymmetry/beatlink/TestRunner.java
+++ b/src/main/test/org/deepsymmetry/beatlink/TestRunner.java
@@ -1,0 +1,23 @@
+package org.deepsymmetry.beatlink;
+
+import org.deepsymmetry.cratedigger.Database;
+import org.deepsymmetry.cratedigger.pdb.RekordboxPdb;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TestRunner {
+
+    // Convenience integration test
+    @Test
+    public void TestRunner() throws Exception {
+        VirtualRekordbox.getInstance().start();
+        System.out.println("Started up!");
+        try {
+            Thread.sleep(600000000);
+        } catch (InterruptedException e) {
+            System.out.println("Interrupted, exiting.");
+        }
+    }
+}


### PR DESCRIPTION
This is the work to enrich the VirtualCdj to be able to accept statuses from the Opus Quad. This is done through the VirtualRekordbox class, which adjusts the Opus quad messages so that we can proxy them to VirtualCdj and any users of VirtualCdj. 