### PR TITLE
Cprepos opus song change detection

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -188,12 +188,12 @@ public class VirtualRekordbox extends LifecycleParticipant {
     /**
      * The value that comes in update packet 0x25 for PSSI data.
      */
-    private static int METADATA_TYPE_IDENTIFIER_PSSI = 10;
+    private static final int METADATA_TYPE_IDENTIFIER_PSSI = 10;
 
     /**
      * The value that comes in update packet 0x25 once per song change
      */
-    private static int METADATA_TYPE_IDENTIFIER_SONG_CHANGE = 1;
+    private static final int METADATA_TYPE_IDENTIFIER_SONG_CHANGE = 1;
 
     /**
      * Used to construct the keep-alive packet we broadcast in order to participate in the DJ Link network.

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -186,12 +186,12 @@ public class VirtualRekordbox extends LifecycleParticipant {
     }
 
     /**
-     * The value that comes in update packet 0x25 for PSSI data.
+     * The value that comes in update packet[0x25] for PSSI data.
      */
     private static final int METADATA_TYPE_IDENTIFIER_PSSI = 10;
 
     /**
-     * The value that comes in update packet 0x25 once per song change
+     * The value that comes in update packet[0x25] once per song change
      */
     private static final int METADATA_TYPE_IDENTIFIER_SONG_CHANGE = 1;
 

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -435,7 +435,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     try {
                         requestPSSI();
                     } catch (IOException e) {
-                        logger.warn("Cannot send PSSI request",data[0x25]);
+                        logger.warn("Cannot send PSSI request");
                         return null;
                     }
                 }

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -436,7 +436,6 @@ public class VirtualRekordbox extends LifecycleParticipant {
                         requestPSSI();
                     } catch (IOException e) {
                         logger.warn("Cannot send PSSI request");
-                        return null;
                     }
                 }
                 return null;

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -343,6 +343,11 @@ public class VirtualRekordbox extends LifecycleParticipant {
      */
     private final Map<Integer, SlotReference> playerTrackSourceSlots = new ConcurrentHashMap<>();
 
+    public void clearPlayerCaches(){
+        playerSongStructures.clear();
+        playerTrackSourceSlots.clear();
+    }
+
     /**
      * Given a player number (normalized to the range 1-4), returns the track source slot associated with the
      * metadata archive that we have matched that player's track to, if any, so we can report it in a meaningful
@@ -429,7 +434,6 @@ public class VirtualRekordbox extends LifecycleParticipant {
                         logger.warn("Cannot send PSSI request",data[0x25]);
                         return null;
                     }
-                    logger.info("data {}",data[0x25]);
                 }
                 return null;
 

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -343,6 +343,10 @@ public class VirtualRekordbox extends LifecycleParticipant {
      */
     private final Map<Integer, SlotReference> playerTrackSourceSlots = new ConcurrentHashMap<>();
 
+    /**
+     * Clear both player caches so that we can reload the data. This usually happens when we load an archive
+     * in OpusProvider.
+     */
     public void clearPlayerCaches(){
         playerSongStructures.clear();
         playerTrackSourceSlots.clear();

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -183,11 +183,14 @@ public class OpusProvider {
                 Thread.sleep(50);
             }
 
-            VirtualCdj.getInstance().deliverMediaDetailsUpdate(newDetails);
+            // Clear player caches as matching data might not be applicable anymore.
+            VirtualRekordbox.getInstance().clearPlayerCaches();
 
             // Request initial PSSI for matching just in case there are songs already loaded on startup.
             // After this we will request PSSI data on song change.
             VirtualRekordbox.getInstance().requestPSSI();
+
+            VirtualCdj.getInstance().deliverMediaDetailsUpdate(newDetails);
         } catch (Exception e) {
             filesystem.close();
             throw new IOException("Problem reading export.pdb from metadata archive " + archiveFile, e);

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -186,8 +186,7 @@ public class OpusProvider {
             // Clear player caches as matching data might not be applicable anymore.
             VirtualRekordbox.getInstance().clearPlayerCaches();
 
-            // Request initial PSSI for matching just in case there are songs already loaded on startup.
-            // After this we will request PSSI data on song change.
+            // Request initial PSSIs for track matching. After this we will request PSSI data on song change.
             VirtualRekordbox.getInstance().requestPSSI();
 
             VirtualCdj.getInstance().deliverMediaDetailsUpdate(newDetails);

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -184,6 +184,10 @@ public class OpusProvider {
             }
 
             VirtualCdj.getInstance().deliverMediaDetailsUpdate(newDetails);
+
+            // Request initial PSSI for matching just in case there are songs already loaded on startup.
+            // After this we will request PSSI data on song change.
+            VirtualRekordbox.getInstance().requestPSSI();
         } catch (Exception e) {
             filesystem.close();
             throw new IOException("Problem reading export.pdb from metadata archive " + archiveFile, e);


### PR DESCRIPTION
1. Asks for and receives PSSI data only once when changing songs. 
2. Clears PSSI caches when we change archives (as that data could be stale) and then requests PSSI data to reload the caches.
