### PR TITLE
Add guard for null getHardwareAddress

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,7 @@
+jdk:
+  - openjdk21
+before_install:
+  - sdk install java 21.0.4-open
+  - sdk use java 21.0.4-open
+  - sdk install maven
+  - mvn -v

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,0 @@
-jdk:
-  - openjdk21
-before_install:
-  - sdk install java 21.0.4-open
-  - sdk use java 21.0.4-open
-  - sdk install maven
-  - mvn -v

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualCdj.java
@@ -927,7 +927,10 @@ public class VirtualCdj extends LifecycleParticipant {
         }
 
         // Copy the chosen interface's hardware and IP addresses into the announcement packet template
-        System.arraycopy(matchingInterfaces.get(0).getHardwareAddress(), 0, keepAliveBytes, MAC_ADDRESS_OFFSET, 6);
+        byte[] addr = matchingInterfaces.get(0).getHardwareAddress();
+        if (addr != null) {
+          System.arraycopy(addr, 0, keepAliveBytes, MAC_ADDRESS_OFFSET, 6);
+        }
         System.arraycopy(matchedAddress.getAddress().getAddress(), 0, keepAliveBytes, 44, 4);
         broadcastAddress.set(matchedAddress.getBroadcast());
 


### PR DESCRIPTION
Fix a java.lang.NullPointerException when running on Android that prevents the VirtualCdj from starting.

Reference docs confirm that modern Android can no longer access the MAC address and therefore return null for this call. 

References:

- https://developer.android.com/reference/java/net/NetworkInterface#getHardwareAddress()
- https://stackoverflow.com/questions/75633495/unable-to-retrieve-mac-address-on-android-11-and-above-using-gethardwareaddress