### PR TITLE
Increase buffer size for incoming packets to accommodate OPUS-QUAD packets

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -896,7 +896,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
         }
 
         // Set up our buffer and packet to receive incoming messages.
-        final byte[] buffer = new byte[512];
+        final byte[] buffer = new byte[1420];
         final DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
 
         // Create the update reception thread


### PR DESCRIPTION
I had some instances where some of my PSSIs were larger than 512 bytes, and would encounter inconsistent behavior with the PSSI checking that was implemented in #74. This PR increases the buffer size for incoming packets from 512 to 1420, the maximum length I've seen the OPUS send through Wireshark.

Note that this doesn't fix the case where the PSSI from the OPUS might span multiple packets, as we still only use the first PSSI packet sent back to us to use to verify.