### PR TITLE
Increase buffer size for incoming packets to accommodate OPUS-QUAD packets

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -614,7 +614,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
      * @return the thread
      */
     private Thread createStatusReceiver() {
-        final byte[] buffer = new byte[512];
+        final byte[] buffer = new byte[1420];
         final DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
 
         // Create the update reception thread


### PR DESCRIPTION
Re-iterating here from #81 (however now this PR goes to the `main` branch):

I had some instances where some of my PSSIs were larger than 512 bytes, and would encounter inconsistent behavior with the PSSI checking that was implemented in https://github.com/Deep-Symmetry/beat-link/pull/74. This PR increases the buffer size for incoming packets from 512 to 1420, the maximum length I've seen the OPUS send through Wireshark.

Note that this doesn't fix the case where the PSSI from the OPUS might span multiple packets, as we still only use the first PSSI packet sent back to us to use to verify.