### PR TITLE
Adjust use of read-only sets

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/BeatFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/BeatFinder.java
@@ -336,7 +336,7 @@ public class BeatFinder extends LifecycleParticipant {
         if (timeFinderListener != null) {
             result.add(timeFinderListener);
         }
-        return Collections.unmodifiableSet(result);
+        return result;
     }
 
     /**

--- a/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
+++ b/src/main/java/org/deepsymmetry/beatlink/DeviceFinder.java
@@ -371,6 +371,13 @@ public class DeviceFinder extends LifecycleParticipant {
      */
     private final Set<DeviceAnnouncementListener> deviceListeners =
             Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Maintains a read-only copy of deviceListeners
+     */
+    private final Set<DeviceAnnouncementListener> deviceListenersImmutable =
+            Collections.unmodifiableSet(deviceListeners);
+
     /**
      * Adds the specified device announcement listener to receive device announcements when DJ Link devices
      * are found on or leave the network. If {@code listener} is {@code null} or already present in the list
@@ -410,8 +417,7 @@ public class DeviceFinder extends LifecycleParticipant {
      */
     @API(status = API.Status.STABLE)
     public Set<DeviceAnnouncementListener> getDeviceAnnouncementListeners() {
-        // Make a copy so callers get an immutable snapshot of the current state.
-        return Set.copyOf(deviceListeners);
+        return deviceListenersImmutable;
     }
 
     /**


### PR DESCRIPTION
Curious about a couple uses of read-only sets.

`DeviceFinder.getDeviceAnnouncementListeners()`:
Using `Set.copyOf()` creates a new collection each time the method is called.  What do you think about this alternative: creating a `Collections.unmodifiableSet()` once, which tracks the contents of `deviceListeners` but is read-only to any callers of the public method.

`BeatFinder.getBeatListeners()`:
`result` is already a unique collection, its contents were copied from `beatListeners`.  Only the caller of `getBeatListeners()` ends up with a reference to `result`.  Wrapping it in an unmodifiableSet adds overhead (by creating another set) but additional protection isn't needed.  The caller of `getBeatListeners()` could modify their copy of the collection without affecting anything else.

