### PR TITLE
Opus Quad PSSI to DeviceSQL ID Map

### DIFF
--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -683,7 +683,7 @@ public class CdjStatus extends DeviceUpdate {
 
         final byte trackSourceByte = packetBytes[0x28];
         if (isFromOpusQuad && (trackSourceByte < 16)) {
-            // sourcePlayer variable will be changed to the slot number
+            // sourcePlayer variable will be changed to the slot number, it's not the deck number
             int sourcePlayer = Util.translateOpusPlayerNumbers(trackSourceByte);
             int player = Util.translateOpusPlayerNumbers(trackSourceByte);
             if (sourcePlayer != 0) {

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -683,13 +683,15 @@ public class CdjStatus extends DeviceUpdate {
 
         final byte trackSourceByte = packetBytes[0x28];
         if (isFromOpusQuad && (trackSourceByte < 16)) {
+            // sourcePlayer variable will be changed to the slot number
             int sourcePlayer = Util.translateOpusPlayerNumbers(trackSourceByte);
+            int player = Util.translateOpusPlayerNumbers(trackSourceByte);
             if (sourcePlayer != 0) {
                 final SlotReference matchedSourceSlot = VirtualRekordbox.getInstance().findMatchedTrackSourceSlotForPlayer(deviceNumber);
                 if (matchedSourceSlot != null) {
                     sourcePlayer = matchedSourceSlot.player;
                 }
-                final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(sourcePlayer);
+                final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
                 if (deviceSqlRekordboxId != 0) {
                     rekordboxId = deviceSqlRekordboxId;
                 }

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -691,8 +691,6 @@ public class CdjStatus extends DeviceUpdate {
                 if (matchedSourceSlot != null) {
                     sourcePlayer = matchedSourceSlot.player;
                 }
-                // TODO: findDeviceSqlRekordboxIdForPlayer function would also return matchedSourceSlot,
-                // replacing the need for the findMatchedTrackSourceSlotForPlayer function.
                 final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
                 if (deviceSqlRekordboxId != 0) {
                     rekordboxId = deviceSqlRekordboxId;

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -691,6 +691,8 @@ public class CdjStatus extends DeviceUpdate {
                 if (matchedSourceSlot != null) {
                     sourcePlayer = matchedSourceSlot.player;
                 }
+                // TODO: findDeviceSqlRekordboxIdForPlayer function would also return matchedSourceSlot,
+                // replacing the need for the findMatchedTrackSourceSlotForPlayer function.
                 final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
                 if (deviceSqlRekordboxId != 0) {
                     rekordboxId = deviceSqlRekordboxId;

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -693,9 +693,7 @@ public class CdjStatus extends DeviceUpdate {
                     sourcePlayer = matchedSourceSlot.player;
                 }
                 final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
-                if (deviceSqlRekordboxId != 0) {
-                    maybeRekordboxId = deviceSqlRekordboxId;
-                }
+                maybeRekordboxId = deviceSqlRekordboxId;
             }
             trackSourcePlayer = sourcePlayer;
             trackSourceSlot = TrackSourceSlot.USB_SLOT;

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -251,7 +251,7 @@ public class CdjStatus extends DeviceUpdate {
      * The rekordbox ID of the track that was loaded, if any; labeled<i>rekordbox</i> in
      * the <a href="https://djl-analysis.deepsymmetry.org/djl-analysis/vcdj.html#cdj-status-packets">Packet Analysis document</a>.
      */
-    private final int rekordboxId;
+    private int rekordboxId;
 
     /**
      * Get the rekordbox ID of the track that was loaded, if any; labeled <i>rekordbox</i> in Figure 11 of
@@ -673,7 +673,6 @@ public class CdjStatus extends DeviceUpdate {
             logger.warn("Processing CDJ Status packets with unexpected lengths {}.", packetBytes.length);
         }
         trackType = findTrackType();
-        rekordboxId = (int)Util.bytesToNumber(packetBytes, 0x2c, 4);
         pitch = (int)Util.bytesToNumber(packetBytes, 0x8d, 3);
         bpm = (int)Util.bytesToNumber(packetBytes, 0x92, 2);
         playState1 = findPlayState1();
@@ -690,6 +689,10 @@ public class CdjStatus extends DeviceUpdate {
                 if (matchedSourceSlot != null) {
                     sourcePlayer = matchedSourceSlot.player;
                 }
+                final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(sourcePlayer);
+                if (deviceSqlRekordboxId != 0) {
+                    rekordboxId = deviceSqlRekordboxId;
+                }
             }
             trackSourcePlayer = sourcePlayer;
             trackSourceSlot = TrackSourceSlot.USB_SLOT;
@@ -698,6 +701,7 @@ public class CdjStatus extends DeviceUpdate {
         } else {
             trackSourcePlayer = trackSourceByte;
             trackSourceSlot = findTrackSourceSlot();
+            rekordboxId = (int)Util.bytesToNumber(packetBytes, 0x2c, 4);
         }
     }
 

--- a/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
+++ b/src/main/java/org/deepsymmetry/beatlink/CdjStatus.java
@@ -251,7 +251,7 @@ public class CdjStatus extends DeviceUpdate {
      * The rekordbox ID of the track that was loaded, if any; labeled<i>rekordbox</i> in
      * the <a href="https://djl-analysis.deepsymmetry.org/djl-analysis/vcdj.html#cdj-status-packets">Packet Analysis document</a>.
      */
-    private int rekordboxId;
+    private final int rekordboxId;
 
     /**
      * Get the rekordbox ID of the track that was loaded, if any; labeled <i>rekordbox</i> in Figure 11 of
@@ -673,6 +673,7 @@ public class CdjStatus extends DeviceUpdate {
             logger.warn("Processing CDJ Status packets with unexpected lengths {}.", packetBytes.length);
         }
         trackType = findTrackType();
+        int maybeRekordboxId = (int)Util.bytesToNumber(packetBytes, 0x2c, 4);
         pitch = (int)Util.bytesToNumber(packetBytes, 0x8d, 3);
         bpm = (int)Util.bytesToNumber(packetBytes, 0x92, 2);
         playState1 = findPlayState1();
@@ -693,7 +694,7 @@ public class CdjStatus extends DeviceUpdate {
                 }
                 final int deviceSqlRekordboxId = VirtualRekordbox.getInstance().findDeviceSqlRekordboxIdForPlayer(player);
                 if (deviceSqlRekordboxId != 0) {
-                    rekordboxId = deviceSqlRekordboxId;
+                    maybeRekordboxId = deviceSqlRekordboxId;
                 }
             }
             trackSourcePlayer = sourcePlayer;
@@ -703,8 +704,9 @@ public class CdjStatus extends DeviceUpdate {
         } else {
             trackSourcePlayer = trackSourceByte;
             trackSourceSlot = findTrackSourceSlot();
-            rekordboxId = (int)Util.bytesToNumber(packetBytes, 0x2c, 4);
         }
+
+        rekordboxId = maybeRekordboxId;
     }
 
     /**

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -434,7 +434,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     
                     // Determine if track has changed and if it's currently loaded
                     boolean isLoaded = status.getTrackSourcePlayer() != 0;
-                    boolean trackChanged = previousId != null && previousId != rawRekordboxId && rawRekordboxId != 0;
+                    boolean trackChanged = previousId != rawRekordboxId && rawRekordboxId != 0;
                     
                     // Clear slot and ID mapping if deck is empty or track has changed
                     if (trackChanged || !isLoaded) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -257,6 +257,8 @@ public class VirtualRekordbox extends LifecycleParticipant {
      */
     private final Map<Integer, SlotReference> playerTrackSourceSlots = new ConcurrentHashMap<>();
 
+    private final Map<Integer, Integer> playerToDeviceSqlRekordboxId = new ConcurrentHashMap<>();
+
     /**
      * Clear both player caches so that we can reload the data. This usually happens when we load an archive
      * in OpusProvider.
@@ -280,6 +282,9 @@ public class VirtualRekordbox extends LifecycleParticipant {
         return playerTrackSourceSlots.get(player);
     }
 
+    public int findDeviceSqlRekordboxIdForPlayer(int player) {
+        return playerToDeviceSqlRekordboxId.getOrDefault(player, 0);
+    }
 
     /**
      * Keeps track of the most recent valid (non-zero) status flag byte we have received from each device number,
@@ -366,6 +371,10 @@ public class VirtualRekordbox extends LifecycleParticipant {
                         final int sourceSlot = OpusProvider.getInstance().findMatchingUsbSlotForTrack(rekordboxId, player, pssiFromOpus);
                         if (sourceSlot != 0) {  // We found a match, record it.
                             playerTrackSourceSlots.put(player, SlotReference.getSlotReference(sourceSlot, USB_SLOT));
+                        }
+                        final int deviceSqlRekordboxId = OpusProvider.getInstance().getDeviceSqlRekordboxIdFromPssi(pssiFromOpus);
+                        if (deviceSqlRekordboxId != 0) {
+                            playerToDeviceSqlRekordboxId.put(player, deviceSqlRekordboxId);
                         }
                     }
                 } else if (data[0x25] == METADATA_TYPE_IDENTIFIER_SONG_CHANGE) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -431,10 +431,11 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     // Get previous ID for comparison, as well as update the map
                     // (put() returns the previous value)
                     Integer previousId = previousRawRekordboxIds.put(status.getDeviceNumber(), rawRekordboxId);
-                    
+                    if (previousId == null) previousId = 0;  // For safe and meaningful comparison with rawRekordboxId
+
                     // Determine if track has changed and if it's currently loaded
                     boolean isLoaded = status.getTrackSourcePlayer() != 0;
-                    boolean trackChanged = previousId != null && previousId != rawRekordboxId && rawRekordboxId != 0;
+                    boolean trackChanged = previousId != rawRekordboxId && rawRekordboxId != 0;
                     
                     // Clear slot and ID mapping if deck is empty or track has changed
                     if (trackChanged || !isLoaded) {
@@ -443,7 +444,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     }
                     
                     // Only request PSSI when there's a new track loaded (ID change)
-                    if (trackChanged) {
+                    if (trackChanged && isLoaded) {
                         try {
                             requestPSSI();
                         } catch (IOException e) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -282,7 +282,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
         return playerTrackSourceSlots.get(player);
     }
 
-    public int findDeviceSqlRekordboxIdForPlayer(int player) {
+    int findDeviceSqlRekordboxIdForPlayer(int player) {
         return playerToDeviceSqlRekordboxId.getOrDefault(player, 0);
     }
 

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -428,8 +428,9 @@ public class VirtualRekordbox extends LifecycleParticipant {
 
                     CdjStatus status = new CdjStatus(packet, hadToRecoverStatusFlags);
 
-                    // Get previous ID for comparison
-                    Integer previousId = previousRawRekordboxIds.get(status.getDeviceNumber());
+                    // Get previous ID for comparison, as well as update the map
+                    // (put() returns the previous value)
+                    Integer previousId = previousRawRekordboxIds.put(status.getDeviceNumber(), rawRekordboxId);
                     
                     // Determine if track has changed and if it's currently loaded
                     boolean isLoaded = status.getTrackSourcePlayer() != 0;
@@ -449,9 +450,6 @@ public class VirtualRekordbox extends LifecycleParticipant {
                             logger.warn("Cannot send PSSI request");
                         }
                     }
-                    
-                    // Update the previous ID for next comparison
-                    previousRawRekordboxIds.put(status.getDeviceNumber(), rawRekordboxId);
                     
                     return status;
                 } else {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -350,8 +350,8 @@ public class VirtualRekordbox extends LifecycleParticipant {
         byte[] getDataAsBytesAndTrimTrailingZeros() {
 
             // Start by removing any trailing zeroes.
-            while (!data.isEmpty() && data.getLast() == 0) {
-                data.removeLast();
+            while (!data.isEmpty() && data.get(data.size() - 1) == 0) {
+                data.remove(data.size() - 1);
             }
 
             // Then convert to regular byte array.

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -374,6 +374,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
 
     /**
      * Packet trackers for each player.
+     * See {@link PacketTracker} for more details.
      */
     private final Map<Integer, PacketTracker> playerPacketTrackers = new ConcurrentHashMap<>();
 

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -475,7 +475,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                         // Get the actual rekordbox DeviceSQL ID and slot number
                         final DeviceSqlRekordboxIdAndSlot match = OpusProvider.getInstance().getDeviceSqlRekordboxIdAndSlotNumberFromPssi(pssiFromOpus, rekordboxIdFromOpus);
 
-                        // Record this song structure for matching tracks in CdjStatus packets
+                        // Record the match in the player maps
                         if (match != null) {
                             playerToDeviceSqlRekordboxId.put(playerNumber, match.getRekordboxId());
                             playerTrackSourceSlots.put(playerNumber, SlotReference.getSlotReference(match.getUsbSlot(), USB_SLOT));

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -294,7 +294,9 @@ public class VirtualRekordbox extends LifecycleParticipant {
 
     /**
      * Tracks packets received from devices to reconstruct complete messages that span multiple packets.
-     * TODO: Doc
+     * Used primarily for reconstructing binary data (specifically PSSI) from the Opus Quad, which 
+     * arrives fragmented across multiple packets. Maintains state between packet
+     * arrivals until a complete message is assembled, at which point the data can be processed.
      */
     private static class PacketTracker {
         private final List<Byte> data;
@@ -359,7 +361,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
     }
 
     /**
-     * TODO: Doc
+     * Packet trackers for each player.
      */
     private final Map<Integer, PacketTracker> playerPacketTrackers = new ConcurrentHashMap<>();
 

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -361,9 +361,12 @@ public class VirtualRekordbox extends LifecycleParticipant {
                 byte[] data = packet.getData();
                 // PSSI Data
                 if (data[0x25] == METADATA_TYPE_IDENTIFIER_PSSI) {
-
+                    final int rekordboxIdFromOpus = (int) Util.bytesToNumber(data, 0x28, 4);
                     final ByteBuffer pssiFromOpus = ByteBuffer.wrap(Arrays.copyOfRange(data, 0x35, data.length));
-                    final int rekordboxId = OpusProvider.getInstance().getDeviceSqlRekordboxIdFromPssi(pssiFromOpus);
+
+                    // Get the actual rekordbox DeviceSQL ID
+                    final int rekordboxId = OpusProvider.getInstance().getDeviceSqlRekordboxIdFromPssi(pssiFromOpus, rekordboxIdFromOpus);
+
                     // Record this song structure so that we can use it for matching tracks in CdjStatus packets.
                     if (rekordboxId != 0) {
                         final int player = Util.translateOpusPlayerNumbers(data[0x21]);

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -439,7 +439,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     // so just initialize previousId to 0 for safe comparison with rawRekordboxId
                     if (previousId == null) previousId = 0;
 
-                    // Determine if track has changed and if it's currently loaded
+                    // Determine if track has changed
                     boolean trackChanged = previousId != rawRekordboxId;
                     
                     // Clear slot and ID mapping if track has changed

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -362,19 +362,16 @@ public class VirtualRekordbox extends LifecycleParticipant {
                 // PSSI Data
                 if (data[0x25] == METADATA_TYPE_IDENTIFIER_PSSI) {
 
-                    final int rekordboxId = (int) Util.bytesToNumber(data, 0x28, 4);
+                    final ByteBuffer pssiFromOpus = ByteBuffer.wrap(Arrays.copyOfRange(data, 0x35, data.length));
+                    final int rekordboxId = OpusProvider.getInstance().getDeviceSqlRekordboxIdFromPssi(pssiFromOpus);
                     // Record this song structure so that we can use it for matching tracks in CdjStatus packets.
                     if (rekordboxId != 0) {
-                        final ByteBuffer pssiFromOpus = ByteBuffer.wrap(Arrays.copyOfRange(data, 0x35, data.length));
                         final int player = Util.translateOpusPlayerNumbers(data[0x21]);
+                        playerToDeviceSqlRekordboxId.put(player, rekordboxId);
                         // Also record the conceptual source slot that represents the USB slot from which this track seems to have been loaded
                         final int sourceSlot = OpusProvider.getInstance().findMatchingUsbSlotForTrack(rekordboxId, player, pssiFromOpus);
                         if (sourceSlot != 0) {  // We found a match, record it.
                             playerTrackSourceSlots.put(player, SlotReference.getSlotReference(sourceSlot, USB_SLOT));
-                        }
-                        final int deviceSqlRekordboxId = OpusProvider.getInstance().getDeviceSqlRekordboxIdFromPssi(pssiFromOpus);
-                        if (deviceSqlRekordboxId != 0) {
-                            playerToDeviceSqlRekordboxId.put(player, deviceSqlRekordboxId);
                         }
                     }
                 } else if (data[0x25] == METADATA_TYPE_IDENTIFIER_SONG_CHANGE) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -469,8 +469,8 @@ public class VirtualRekordbox extends LifecycleParticipant {
 
                         // Record the match in the player maps
                         if (match != null) {
-                            playerToDeviceSqlRekordboxId.put(playerNumber, match.getRekordboxId());
-                            playerTrackSourceSlots.put(playerNumber, SlotReference.getSlotReference(match.getUsbSlot(), USB_SLOT));
+                            playerToDeviceSqlRekordboxId.put(playerNumber, match.rekordboxId);
+                            playerTrackSourceSlots.put(playerNumber, SlotReference.getSlotReference(match.usbSlot, USB_SLOT));
                         }
                     }
                 } else if (data[0x25] == METADATA_TYPE_IDENTIFIER_SONG_CHANGE) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -434,7 +434,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     
                     // Determine if track has changed and if it's currently loaded
                     boolean isLoaded = status.getTrackSourcePlayer() != 0;
-                    boolean trackChanged = previousId != rawRekordboxId && rawRekordboxId != 0;
+                    boolean trackChanged = previousId != null && previousId != rawRekordboxId && rawRekordboxId != 0;
                     
                     // Clear slot and ID mapping if deck is empty or track has changed
                     if (trackChanged || !isLoaded) {

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -330,10 +330,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                 data.add(b);
             }
 
-            if (packetNumber == totalPackets) {
-                return true;
-            }
-            return false;
+            return packetNumber == totalPackets;
         }
 
         /**
@@ -351,21 +348,16 @@ public class VirtualRekordbox extends LifecycleParticipant {
          * @return the complete message data with trailing zeros removed
          */
         byte[] getDataAsBytesAndTrimTrailingZeros() {
-            // First convert to regular byte array
+
+            // Start by removing any trailing zeroes.
+            while (!data.isEmpty() && data.getLast() == 0) {
+                data.removeLast();
+            }
+
+            // Then convert to regular byte array.
             byte[] result = new byte[data.size()];
             for (int i = 0; i < data.size(); i++) {
                 result[i] = data.get(i);
-            }
-
-            // Find last non-zero byte
-            int lastNonZero = result.length - 1;
-            while (lastNonZero >= 0 && result[lastNonZero] == 0) {
-                lastNonZero--;
-            }
-
-            // If we found trailing zeros, create a new trimmed array
-            if (lastNonZero < result.length - 1) {
-                return Arrays.copyOf(result, lastNonZero + 1);
             }
 
             return result;

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -499,10 +499,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                             playerTrackSourceSlots.put(playerNumber, SlotReference.getSlotReference(match.usbSlot, USB_SLOT));
                         }
                     }
-                } else if (data[0x25] == METADATA_TYPE_IDENTIFIER_SONG_CHANGE) {
-                    // This was one way to detect a track change, but the packet is sent too slow after a track change,
-                    // instead we detect for an ID change in between status packets in the CDJ_STATUS case above.
-                }
+                } 
                 return null;
 
             default:

--- a/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
+++ b/src/main/java/org/deepsymmetry/beatlink/VirtualRekordbox.java
@@ -435,7 +435,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
 
                     // Determine if track has changed and if it's currently loaded
                     boolean isLoaded = status.getTrackSourcePlayer() != 0;
-                    boolean trackChanged = previousId != rawRekordboxId && rawRekordboxId != 0;
+                    boolean trackChanged = previousId != rawRekordboxId;
                     
                     // Clear slot and ID mapping if deck is empty or track has changed
                     if (trackChanged || !isLoaded) {
@@ -444,7 +444,7 @@ public class VirtualRekordbox extends LifecycleParticipant {
                     }
                     
                     // Only request PSSI when there's a new track loaded (ID change)
-                    if (trackChanged && isLoaded) {
+                    if (trackChanged) {
                         try {
                             requestPSSI();
                         } catch (IOException e) {

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -218,6 +218,8 @@ public class OpusProvider {
                     } else {
                         logger.warn("No SONG_STRUCTURE found for track {}", i);
                     }
+                } else {
+                    logger.warn("No extended analysis found for track {}", i);
                 }
             }
 

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -589,7 +589,7 @@ public class OpusProvider {
         }
     };
 
-    private int getDeviceSqlRekordboxIdFromPssi(ByteBuffer pssi) {
+    public int getDeviceSqlRekordboxIdFromPssi(ByteBuffer pssi) {
         // logger.info("getDeviceSqlRekordboxIdFromPssi() called with pssi: {}", pssi.array());
         for (Map.Entry<RekordboxAnlz, Integer> entry : pssiToDeviceSqlRekordboxId.entrySet()) {
             RekordboxAnlz anlz = entry.getKey();

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -315,6 +315,8 @@ public class OpusProvider {
 
                 // If we got here, this looks like a valid metadata archive because we found a valid DeviceSQL database export inside it.
                 openedArchive = new RekordboxUsbArchive(usbSlotNumber, database, null, filesystem);
+                newDetails = new MediaDetails(slotReference, CdjStatus.TrackType.REKORDBOX, filesystem.toString(),
+                    database.trackIndex.size(), database.playlistIndex.size(), database.sourceFile.lastModified());
 
                 // Populate pssiToDeviceSqlRekordboxId
                 SlotReference slotRef = SlotReference.getSlotReference(1, CdjStatus.TrackSourceSlot.USB_SLOT);
@@ -351,9 +353,7 @@ public class OpusProvider {
                 }
 
                 logger.info("pssiToDeviceSqlRekordboxId is now filled with {} entries", pssiToDeviceSqlRekordboxId.size());
-                    newDetails = new MediaDetails(slotReference, CdjStatus.TrackType.REKORDBOX, filesystem.toString(),
-                            database.trackIndex.size(), database.playlistIndex.size(), database.sourceFile.lastModified());
-                    logger.info("Attached DeviceSQL metadata archive {} for slot {}.", filesystem, usbSlotNumber);
+                logger.info("Attached DeviceSQL metadata archive {} for slot {}.", filesystem, usbSlotNumber);
                 } catch (Exception e) {
                     filesystem.close();
                     throw new IOException("Problem reading export.pdb from metadata archive " + archiveFile, e);

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -838,7 +838,7 @@ public class OpusProvider {
             // If the Opus sent back an ID that we don't have a match for,
             // we'll just return the first match we found.
             DeviceSqlRekordboxIdAndSlot firstMatch = matches.get(0);
-            logger.info("Multiple PSSI matches found but none match ID from Opus: {}. Returning the first match: {}", idSentFromOpus, firstMatch);
+            logger.info("Multiple PSSI matches found, but none match ID sent from Opus: {}. Returning the first match: {}", idSentFromOpus, firstMatch);
             return firstMatch;
         }
     }

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -617,8 +617,6 @@ public class OpusProvider {
      */
     private boolean trackMatchesArchive(DataReference dataRef, ByteBuffer pssiFromOpus, RekordboxUsbArchive archive) {
         RekordboxAnlz anlz = findExtendedAnalysis(archive.getUsbSlot(), dataRef, archive.getDatabase(), archive.getFileSystem());
-        int deviceSqlRekordboxId = getDeviceSqlRekordboxIdFromPssi(pssiFromOpus);
-        logger.info("According to getDeviceSqlRekordboxIdFromPssi(), the deviceSqlRekordboxId is {}", deviceSqlRekordboxId);
         if (anlz != null) {
             for (RekordboxAnlz.TaggedSection taggedSection : anlz.sections()) {
                 if (taggedSection.fourcc() == RekordboxAnlz.SectionTags.SONG_STRUCTURE) {

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -252,6 +252,12 @@ public class OpusProvider {
 
                 // Clear player caches as matching data is not applicable anymore.
                 VirtualRekordbox.getInstance().clearPlayerCaches(usbSlotNumber);
+                
+                // Clean up PSSI mapping for this USB slot
+                pssiToDeviceSqlRekordboxId.entrySet().removeIf(entry -> 
+                    entry.getValue().getUsbSlot() == usbSlotNumber);
+                logger.info("Removed PSSI mappings for slot {}, pssiToDeviceSqlRekordboxId now has {} entries", 
+                    usbSlotNumber, pssiToDeviceSqlRekordboxId.size());
             } catch (IOException e) {
                 logger.error("Problem closing database or FileSystem for slot {}", usbSlotNumber, e);
             }

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -166,13 +166,10 @@ public class OpusProvider {
     public static class DeviceSqlRekordboxIdAndSlot {
         private final int rekordboxId;
         private final int usbSlot;
-        // Storing songStructure for debugging purposes
-        private final byte[] songStructure;
     
-        private DeviceSqlRekordboxIdAndSlot(int rekordboxId, int usbSlot, byte[] songStructure) {
+        private DeviceSqlRekordboxIdAndSlot(int rekordboxId, int usbSlot) {
             this.rekordboxId = rekordboxId;
             this.usbSlot = usbSlot;
-            this.songStructure = songStructure;
         }
     
         public int getRekordboxId() {
@@ -181,10 +178,6 @@ public class OpusProvider {
     
         public int getUsbSlot() {
             return usbSlot;
-        }
-
-        public byte[] getSongStructure() {
-            return songStructure;
         }
     }
 
@@ -340,7 +333,7 @@ public class OpusProvider {
                                 logger.warn("Could not calculate SHA-1 for track {}", i);
                                 continue;
                             }
-                            pssiToDeviceSqlRekordboxId.put(sha1, new DeviceSqlRekordboxIdAndSlot(i, usbSlotNumber, songStructure));
+                            pssiToDeviceSqlRekordboxId.put(sha1, new DeviceSqlRekordboxIdAndSlot(i, usbSlotNumber));
                         } else {
                             logger.warn("No SONG_STRUCTURE found for track {}", i);
                         }

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -198,7 +198,16 @@ public class OpusProvider {
             // Populate pssiToDeviceSqlRekordboxId
             SlotReference slotRef = SlotReference.getSlotReference(1, CdjStatus.TrackSourceSlot.USB_SLOT);
 
-            for (int i = 1; i <= 9999; i++) {
+            // Get max ID first
+            // This can be found by finding the max key in database.trackIndex
+            int maxId = 0;
+            for (Long key : database.trackIndex.keySet()) {
+                if (key > maxId) {
+                    maxId = key.intValue();
+                }
+            }
+
+            for (int i = 1; i <= maxId; i++) {
                 DataReference dataRef = new DataReference(slotRef, i);
                 RekordboxAnlz anlz = findExtendedAnalysis(usbSlotNumber, dataRef, database, filesystem);
                 if (anlz != null) {

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -187,7 +187,7 @@ public class OpusProvider {
     private final Map<String, DeviceSqlRekordboxIdAndSlot> pssiToDeviceSqlRekordboxId = new ConcurrentHashMap<>();
 
     /**
-     * Compute the SHA1 hash of the given data, similiar to SignatureFinder.computeTrackSignature().
+     * Compute the SHA1 hash of the given data, similar to {@link SignatureFinder#computeTrackSignature(String, SearchableItem, int, WaveformDetail, BeatGrid)}.
      * @param data the data to hash
      * @return the SHA1 hash of the data, or {@code null} if there is an error
      */

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -161,7 +161,7 @@ public class OpusProvider {
     private final Map<Integer, LinkedBlockingQueue<MediaDetails>> archiveAttachQueueMap = new ConcurrentHashMap<>();
 
     /**
-     * TODO: Doc
+     * Object to store a rekordbox ID and USB slot number together.
      */
     public static class DeviceSqlRekordboxIdAndSlot {
         private final int rekordboxId;
@@ -182,12 +182,14 @@ public class OpusProvider {
     }
 
     /**
-     * TODO: Doc
+     * A SHA1 hash of the song structure of a track, mapped to the corresponding DeviceSQL rekordbox ID and USB slot.
      */
     private final Map<String, DeviceSqlRekordboxIdAndSlot> pssiToDeviceSqlRekordboxId = new ConcurrentHashMap<>();
 
     /**
-     * TODO: Doc
+     * Compute the SHA1 hash of the given data, similiar to SignatureFinder.computeTrackSignature().
+     * @param data the data to hash
+     * @return the SHA1 hash of the data, or {@code null} if there is an error
      */
     private String computeSha1(byte[] data) {
         try {

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -644,13 +644,18 @@ public class OpusProvider {
         } else if (matches.size() == 1) {
             return matches.get(0);
         } else {
-            // Multiple matches found - look for exact ID match first
+            // Multiple matches found - prefer the match with the same ID sent from the Opus
             if (matches.contains(idSentFromOpus)) {
-                logger.info("Multiple PSSI matches found, using ID sent from Opus: {}", idSentFromOpus);
+                logger.info("Multiple PSSI matches found, preferring ID sent from Opus: {}", idSentFromOpus);
                 return idSentFromOpus;
             }
-            logger.warn("Multiple PSSI matches found but none match ID from Opus: {}", idSentFromOpus);
-            return 0;
+            // If the Opus sent back an ID that we don't have a match for,
+            // we'll just return the first match we found. (By this point
+            // we are experiencing de-synced databases between the DeviceSQL and Device Library Plus,
+            // see: https://deep-symmetry.zulipchat.com/#narrow/channel/275322-beat-link-trigger/topic/Opus.20Quad.20Integration/near/495932074)
+            int firstMatch = matches.get(0);
+            logger.info("Multiple PSSI matches found but none match ID from Opus: {}. Returning the first match: {}", idSentFromOpus, firstMatch);
+            return firstMatch;
         }
     }
 

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -836,9 +836,7 @@ public class OpusProvider {
                 }
             }
             // If the Opus sent back an ID that we don't have a match for,
-            // we'll just return the first match we found. (By this point
-            // we are experiencing de-synced databases between the DeviceSQL and Device Library Plus,
-            // see: https://deep-symmetry.zulipchat.com/#narrow/channel/275322-beat-link-trigger/topic/Opus.20Quad.20Integration/near/495932074)
+            // we'll just return the first match we found.
             DeviceSqlRekordboxIdAndSlot firstMatch = matches.get(0);
             logger.info("Multiple PSSI matches found but none match ID from Opus: {}. Returning the first match: {}", idSentFromOpus, firstMatch);
             return firstMatch;

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -214,6 +214,8 @@ public class OpusProvider {
                     // Get the SONG_STRUCTURE raw body
                     byte[] songStructure = getSongStructureRawBody(anlz);
                     if (songStructure != null) {
+                        // TODO: The map should also include usbSlotNumber,
+                        // so we don't have to take care of slot matching separately.
                         pssiToDeviceSqlRekordboxId.put(songStructure, i);
                     } else {
                         logger.warn("No SONG_STRUCTURE found for track {}", i);

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -468,6 +468,11 @@ public class OpusProvider {
         return findTrackAnalysis(usbSlotNumber, track, database, connection, filesystem, ".EXT");
     }
 
+    /**
+     * Get the raw body of the SONG_STRUCTURE section of the extended analysis file.
+     * @param anlz the extended analysis file to search
+     * @return the raw body of the SONG_STRUCTURE section, or {@code null} if no SONG_STRUCTURE section is found
+     */
     private byte[] getSongStructureRawBody(RekordboxAnlz anlz) {
         for (RekordboxAnlz.TaggedSection section : anlz.sections()) {
             if (section.fourcc() == RekordboxAnlz.SectionTags.SONG_STRUCTURE) {
@@ -799,6 +804,14 @@ public class OpusProvider {
         }
     };
 
+    /**
+     * Given a PSSI message and the ID sent from the Opus, return the DeviceSQL rekordbox ID and USB slot number
+     * that matches the PSSI. Also handle multiple matches, preferring the match with the same ID sent from the Opus, otherwise
+     * returning the first match found.
+     * @param pssi the PSSI message
+     * @param idSentFromOpus the ID sent from the Opus
+     * @return the DeviceSQL rekordbox ID and USB slot number that matches the PSSI, or {@code null} if no match is found
+     */
     public DeviceSqlRekordboxIdAndSlot getDeviceSqlRekordboxIdAndSlotNumberFromPssi(byte[] pssi, int idSentFromOpus) {
         // From observation, the actual part we need to check from the
         // body sent from the Opus is starting at index 12

--- a/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
+++ b/src/main/java/org/deepsymmetry/beatlink/data/OpusProvider.java
@@ -281,7 +281,7 @@ public class OpusProvider {
             // Further clean up by removing any SHA-1 hashes that no longer have matches.
             pssiToDeviceSqlRekordboxIds.entrySet().removeIf(entry -> entry.getValue().isEmpty());
 
-            logger.info("Removed PSSI mappings for slot {}, pssiToDeviceSqlRekordboxId now has {} entries",
+            logger.info("Removed PSSI mappings for slot {}, pssiToDeviceSqlRekordboxIds now has {} entries",
                     usbSlotNumber, pssiToDeviceSqlRekordboxIds.size());
 
             // Clean up any extracted files associated with this archive.
@@ -338,7 +338,7 @@ public class OpusProvider {
                 newDetails = new MediaDetails(slotReference, CdjStatus.TrackType.REKORDBOX, filesystem.toString(),
                     database.trackIndex.size(), database.playlistIndex.size(), database.sourceFile.lastModified());
 
-                // Populate pssiToDeviceSqlRekordboxId
+                // Populate pssiToDeviceSqlRekordboxIds
                 SlotReference slotRef = SlotReference.getSlotReference(1, CdjStatus.TrackSourceSlot.USB_SLOT);
 
                 for (long key : database.trackIndex.keySet()) {
@@ -366,7 +366,7 @@ public class OpusProvider {
                     }
                 }
 
-                logger.info("pssiToDeviceSqlRekordboxId now contains {} entries", pssiToDeviceSqlRekordboxIds.size());
+                logger.info("pssiToDeviceSqlRekordboxIds now contains {} entries", pssiToDeviceSqlRekordboxIds.size());
                 logger.info("Attached DeviceSQL metadata archive {} for slot {}.", filesystem, usbSlotNumber);
                 } catch (Exception e) {
                     filesystem.close();


### PR DESCRIPTION
This branch uses the received PSSI from the Opus Quad to match metadata, instead of the sent ID.

We recently found out that, most likely, the Opus sends back the Device Library Plus ID, instead of the DeviceSQL ID. Since we only have access to the DeviceSQL database to create metadata archives, this will cause problems when the two databases get out of sync--which I first encountered a few weeks ago.

More details in the Zulip thread: https://deep-symmetry.zulipchat.com/#narrow/channel/275322-beat-link-trigger/topic/Opus.20Quad.20Integration/near/495624040

## Todo

- [x] Use PSSI to match metadata
- [x] Behavior when two PSSI matches are found
- [x] Get the whole PSSI from Opus -- add a packet tracker that can re-construct the whole message from fragmented packets
- [x] Couple the USB slot matching with the PSSI matching logic
- [x] Handle removing metadata archives
- [x] Confirm `createStatusReceiver` byte buffer length *(confirmed it is 1420 bytes, was confused looking at Wireshark whether the byte array needs to allocate for the UDP headers as well -- and it doesn't need to)*
- [x] General documentation on new functions
- [x] Compare behaviors in Player Status window with current BLT snapshot, to see if it's consistent
  - [x] Loading another track on the deck -- probably a race condition on my branch, for a few seconds after loading a new song, the old metadata is still there. Observed that the snapshot shows the "[no track metadata available]" between switching tracks. Fixed in 93f98969e3336172c7b4a3650c0f5d2b2129dd57
  - [x] Removing metadata archive -- title and artist still stay showing on Player Status window when an archive is unloaded
- [x] What to do in "Multiple PSSI matches found, but none match ID sent from Opus" case